### PR TITLE
change version of mcrcon to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-telegram-bot==20.7
-mcrcon==0.7.1 
+mcrcon==0.7.0


### PR DESCRIPTION
Исправление ошибки

```
eunik-jenkins@ccessible-point:/app/jenkins$ pip install -r requirements.txt --break-system-packages
Defaulting to user installation because normal site-packages is not writeable
Collecting python-telegram-bot==20.7 (from -r requirements.txt (line 1))
  Downloading python_telegram_bot-20.7-py3-none-any.whl.metadata (15 kB)
ERROR: Could not find a version that satisfies the requirement mcrcon==0.7.1 (from versions: 0.5.1, 0.5.2, 0.6.0, 0.7.0)
ERROR: No matching distribution found for mcrcon==0.7.1
```